### PR TITLE
Add "Migrating from Bitnami Phabricator Stack" section into README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,12 +388,12 @@ You can follow these steps in order to migrate it to this container:
   $ scp ~/backup-phabricator-* YOUR_USERNAME@TARGET_HOST:~
   ```
 
-3. Create the Phabricator Container as described in the section #How to use this Image
+3. Create the Phabricator Container as described in the section #How to use this Image (Using Docker Compose)
 
 4. Wait for the initial setup to finish. You can follow it with
 
   ```bash
-  $ docker logs -f phabricator
+  $ docker-compose logs -f phabricator
   ```
 
   and press `Ctrl-C` when you see this:
@@ -409,34 +409,34 @@ You can follow these steps in order to migrate it to this container:
 5. Stop Phabricator daemon:
 
   ```bash
-  $ docker exec phabricator nami stop phabricator
+  $ docker-compose exec phabricator nami stop phabricator
   ```
 
 6. Restore and upgrade the database: (replace ROOT_PASSWORD below with your MariaDB root password)
 
   ```bash
   $ cd ~
-  $ docker exec phabricator /opt/bitnami/phabricator/bin/storage destroy --force
-  $ gunzip -c ./backup-phabricator-mysql-dumps.sql.gz | docker exec -i mariadb mysql -pROOT_PASSWORD
-  $ docker exec phabricator /opt/bitnami/phabricator/bin/storage upgrade --force
+  $ docker-compose exec phabricator /opt/bitnami/phabricator/bin/storage destroy --force
+  $ gunzip -c ./backup-phabricator-mysql-dumps.sql.gz | docker-compose exec mariadb mysql -pROOT_PASSWORD
+  $ docker-compose exec phabricator /opt/bitnami/phabricator/bin/storage upgrade --force
   ```
 
 7. Restore repositories from backup:
 
   ```bash
-  $ cat ./backup-phabricator-repos.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/repo ; tar -xzvf -'
+  $ cat ./backup-phabricator-repos.tar.gz | docker-compose exec phabricator bash -c 'cd /bitnami/phabricator/repo ; tar -xzvf -'
   ```
 
 8. Restore local storage files:
 
   ```bash
-  $ cat ./backup-phabricator-localstorage.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/data ; tar -xzvf -'
+  $ cat ./backup-phabricator-localstorage.tar.gz | docker-compose exec phabricator bash -c 'cd /bitnami/phabricator/data ; tar -xzvf -'
   ```
 
 9. Fix repositories storage location: (replace ROOT_PASSWORD below with your MariaDB root password)
 
   ```bash
-  $ cat | docker exec -i mariadb mysql -pROOT_PASSWORD <<EOF
+  $ cat | docker-compose exec mariadb mysql -pROOT_PASSWORD <<EOF
   USE bitnami_phabricator_repository;
   UPDATE repository SET localPath = REPLACE(localPath, '/bitnami/apps/phabricator/repo/', '/opt/bitnami/phabricator/repo/');
   COMMIT;
@@ -446,13 +446,13 @@ You can follow these steps in order to migrate it to this container:
 10. Fix phabricator directory permissions:
 
   ```bash
-  $ docker exec phabricator chown -R phabricator:phabricator /bitnami/phabricator
+  $ docker-compose exec phabricator chown -R phabricator:phabricator /bitnami/phabricator
   ```
 
 11. Restart Phabricator container:
 
   ```bash
-  $ docker restart phabricator
+  $ docker-compose restart phabricator
   ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -374,16 +374,18 @@ You can follow these steps in order to migrate it to this container:
 1. Export the data from your SOURCE installation: (assuming an installation in `/bitnami` directory)
 
 ```bash
-$ cd ~
-$ /bitnami/phabricator/bin/storage dump | gzip > ./backup-phabricator-mysql-dumps.sql.gz
-$ tar -zcvf ./backup-phabricator-localstorage.tar.gz /bitnami/phabricator/data
-$ tar -zcvf ./backup-phabricator-repos.tar.gz /bitnami/phabricator/repo
+$ cd /bitnami/phabricator/apps/phabricator/htdocs/bin
+$ ./storage dump | gzip > ~/backup-phabricator-mysql-dumps.sql.gz
+$ cd /bitnami/phabricator/apps/phabricator/data/
+$ tar -zcvf ~/backup-phabricator-localstorage.tar.gz .
+$ cd /bitnami/phabricator/apps/phabricator/repo/
+$ tar -zcvf ~/backup-phabricator-repos.tar.gz .
 ```
 
 2. Copy the backup files to your TARGET installation:
 
 ```bash
-$ scp ./backup-phabricator-* YOUR_USERNAME@TARGET_HOST:~
+$ scp ~/backup-phabricator-* YOUR_USERNAME@TARGET_HOST:~
 ```
 
 3. Create the Phabricator Container as described in the section #How to use this Image
@@ -422,13 +424,13 @@ $ docker exec phabricator /opt/bitnami/phabricator/bin/storage upgrade --force
 7. Restore repositories from backup:
 
 ```bash
-$ cat ./backup-phabricator-repos.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/repo ; tar -pxzvf -'
+$ cat ./backup-phabricator-repos.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/repo ; tar -xzvf -'
 ```
 
 8. Restore local storage files:
 
 ```bash
-$ cat ./backup-phabricator-localstorage.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/data ; tar -pxzvf -'
+$ cat ./backup-phabricator-localstorage.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/data ; tar -xzvf -'
 ```
 
 9. Fix repositories storage location: (replace ROOT_PASSWORD below with your MariaDB root password)

--- a/README.md
+++ b/README.md
@@ -373,87 +373,87 @@ You can follow these steps in order to migrate it to this container:
 
 1. Export the data from your SOURCE installation: (assuming an installation in `/bitnami` directory)
 
-```bash
-$ cd /bitnami/phabricator/apps/phabricator/htdocs/bin
-$ ./storage dump | gzip > ~/backup-phabricator-mysql-dumps.sql.gz
-$ cd /bitnami/phabricator/apps/phabricator/data/
-$ tar -zcvf ~/backup-phabricator-localstorage.tar.gz .
-$ cd /bitnami/phabricator/apps/phabricator/repo/
-$ tar -zcvf ~/backup-phabricator-repos.tar.gz .
-```
+  ```bash
+  $ cd /bitnami/phabricator/apps/phabricator/htdocs/bin
+  $ ./storage dump | gzip > ~/backup-phabricator-mysql-dumps.sql.gz
+  $ cd /bitnami/phabricator/apps/phabricator/data/
+  $ tar -zcvf ~/backup-phabricator-localstorage.tar.gz .
+  $ cd /bitnami/phabricator/apps/phabricator/repo/
+  $ tar -zcvf ~/backup-phabricator-repos.tar.gz .
+  ```
 
 2. Copy the backup files to your TARGET installation:
 
-```bash
-$ scp ~/backup-phabricator-* YOUR_USERNAME@TARGET_HOST:~
-```
+  ```bash
+  $ scp ~/backup-phabricator-* YOUR_USERNAME@TARGET_HOST:~
+  ```
 
 3. Create the Phabricator Container as described in the section #How to use this Image
 
 4. Wait for the initial setup to finish. You can follow it with
 
-```bash
-$ docker logs -f phabricator
-```
+  ```bash
+  $ docker logs -f phabricator
+  ```
 
-and press `Ctrl-C` when you see this:
+  and press `Ctrl-C` when you see this:
 
-```
-nami    INFO  phabricator successfully initialized
-Starting application ...
+  ```
+  nami    INFO  phabricator successfully initialized
+  Starting application ...
 
-  *** Welcome to the phabricator image ***
-  *** Brought to you by Bitnami ***
-```
+    *** Welcome to the phabricator image ***
+    *** Brought to you by Bitnami ***
+  ```
 
 5. Stop Phabricator daemon:
 
-```bash
-$ docker exec phabricator nami stop phabricator
-```
+  ```bash
+  $ docker exec phabricator nami stop phabricator
+  ```
 
 6. Restore and upgrade the database: (replace ROOT_PASSWORD below with your MariaDB root password)
 
-```bash
-$ cd ~
-$ docker exec phabricator /opt/bitnami/phabricator/bin/storage destroy --force
-$ gunzip -c ./backup-phabricator-mysql-dumps.sql.gz | docker exec -i mariadb mysql -pROOT_PASSWORD
-$ docker exec phabricator /opt/bitnami/phabricator/bin/storage upgrade --force
-```
+  ```bash
+  $ cd ~
+  $ docker exec phabricator /opt/bitnami/phabricator/bin/storage destroy --force
+  $ gunzip -c ./backup-phabricator-mysql-dumps.sql.gz | docker exec -i mariadb mysql -pROOT_PASSWORD
+  $ docker exec phabricator /opt/bitnami/phabricator/bin/storage upgrade --force
+  ```
 
 7. Restore repositories from backup:
 
-```bash
-$ cat ./backup-phabricator-repos.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/repo ; tar -xzvf -'
-```
+  ```bash
+  $ cat ./backup-phabricator-repos.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/repo ; tar -xzvf -'
+  ```
 
 8. Restore local storage files:
 
-```bash
-$ cat ./backup-phabricator-localstorage.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/data ; tar -xzvf -'
-```
+  ```bash
+  $ cat ./backup-phabricator-localstorage.tar.gz | docker exec -i phabricator bash -c 'cd /bitnami/phabricator/data ; tar -xzvf -'
+  ```
 
 9. Fix repositories storage location: (replace ROOT_PASSWORD below with your MariaDB root password)
 
-```bash
-$ cat | docker exec -i mariadb mysql -pROOT_PASSWORD <<EOF
-USE bitnami_phabricator_repository;
-UPDATE repository SET localPath = REPLACE(localPath, '/bitnami/apps/phabricator/repo/', '/opt/bitnami/phabricator/repo/');
-COMMIT;
-EOF
-```
+  ```bash
+  $ cat | docker exec -i mariadb mysql -pROOT_PASSWORD <<EOF
+  USE bitnami_phabricator_repository;
+  UPDATE repository SET localPath = REPLACE(localPath, '/bitnami/apps/phabricator/repo/', '/opt/bitnami/phabricator/repo/');
+  COMMIT;
+  EOF
+  ```
 
 10. Fix phabricator directory permissions:
 
-```bash
-$ docker exec phabricator chown -R phabricator:phabricator /bitnami/phabricator
-```
+  ```bash
+  $ docker exec phabricator chown -R phabricator:phabricator /bitnami/phabricator
+  ```
 
 11. Restart Phabricator container:
 
-```bash
-$ docker restart phabricator
-```
+  ```bash
+  $ docker restart phabricator
+  ```
 
 # Contributing
 


### PR DESCRIPTION
First, I'm terribly sorry for the lateness of this PR. I promised it three months ago! 😞 

These steps works with versions `2016.46-r4` and below. They probably work with newer versions but I can't make them work (see #41) to make sure.

However, I need a favor: I don't have access to any working Bitnami Phabricator Stacks anymore. And while I can assert the steps for the TARGET installation works, I need some check with the steps for the SOURCE installation.

More precisely, **I need to check the correctness of `tar` commands** from the initial steps (exporting data from the source installation). I don't know if they are creating the files in the correct folder or in the "off by one" folder (lacking a trailing "/"?)

This is a first draft written by me in the last hour based on my annotations from previous migrations. Suggestions and critics are welcome!

Thanks everybody for this fantastic piece of work!