### PR TITLE
#79 Correct README.md curl download path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://www.phacility.com/phabricator/
 ## Docker Compose
 
 ```bash
-$ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-prestashop/master/docker-compose.yml > docker-compose.yml
+$ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-phabricator/master/docker-compose.yml > docker-compose.yml
 $ docker-compose up -d
 ```
 


### PR DESCRIPTION
fix: Correct README.md curl download path

Original curl download path is incorrect

Modify to bitnami-docker-phabricator