### PR TITLE
add ssh capability, the port is configurable

### DIFF
--- a/2019/debian-9/Dockerfile
+++ b/2019/debian-9/Dockerfile
@@ -2,7 +2,7 @@ FROM bitnami/minideb-extras:stretch-r440
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
 # Install required system packages and dependencies
-RUN install_packages libbz2-1.0 libc6 libcomerr2 libcurl3 libexpat1 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu57 libidn11 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses5 libnettle6 libnghttp2-14 libp11-kit0 libpcre3 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libsqlite3-0 libssh2-1 libssl1.0.2 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5 libtinfo5 libunistring0 libxml2 libxslt1.1 libzip4 openssh-client zlib1g
+RUN install_packages libbz2-1.0 libc6 libcomerr2 libcurl3 libexpat1 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu57 libidn11 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses5 libnettle6 libnghttp2-14 libp11-kit0 libpcre3 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libsqlite3-0 libssh2-1 libssl1.0.2 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5 libtinfo5 libunistring0 libxml2 libxslt1.1 libzip4 openssh-client zlib1g openssh-server python-pygments
 RUN bitnami-pkg unpack apache-2.4.39-2 --checksum ff55ee9cccf484bac61fa91558fc7f8445e91ea00bb104aca216f08aea003c6b
 RUN bitnami-pkg unpack php-7.3.8-0 --checksum cc67ec3f4ff34c0f757e59e28b43572c4b20b938b84cd88a09a186dfd327abd0
 RUN bitnami-pkg install mysql-client-10.3.17-0 --checksum 71d59fafc3e7e3e598af0c2b6788d77558630afe647ec1f922ffdd5025f3d737
@@ -36,6 +36,10 @@ ENV APACHE_HTTPS_PORT_NUMBER="" \
     SMTP_PORT="" \
     SMTP_PROTOCOL="" \
     SMTP_USER=""
+    PHABRICATOR_SSH_PORT_NUMBER="" \
+    PHABRICATOR_ALLOW_GIT_LFS=""
+
+VOLUME [ "/certs" ]
 
 VOLUME [ "/certs" ]
 

--- a/2019/debian-9/rootfs/run.sh
+++ b/2019/debian-9/rootfs/run.sh
@@ -13,6 +13,35 @@ _forwardTerm () {
 
 trap _forwardTerm TERM
 
+if [ "${PHABRICATOR_SSH_PORT_NUMBER}" != "" ] && [ "${PHABRICATOR_SSH_PORT_NUMBER}" != "22" ] ; then
+    PHABRICATOR_SSH_USER="git"
+    if ! id $PHABRICATOR_SSH_USER > /dev/null 2>&1; then
+        useradd -m $PHABRICATOR_SSH_USER
+    fi
+    usermod -p '*' $PHABRICATOR_SSH_USER
+
+    echo "$PHABRICATOR_SSH_USER ALL=(daemon) SETENV: NOPASSWD: /opt/bitnami/git/bin/git-upload-pack, /opt/bitnami/git/bin/git-receive-pack" >> /etc/sudoers
+
+    cp /opt/bitnami/phabricator/resources/sshd/phabricator-ssh-hook.sh /usr/share/
+    sed -i s/VCSUSER=.*/VCSUSER=\"$PHABRICATOR_SSH_USER\"/i /usr/share/phabricator-ssh-hook.sh
+    sed -i 's|ROOT=.*|ROOT=\"/opt/bitnami/phabricator\"|i' /usr/share/phabricator-ssh-hook.sh
+    chown root /usr/share/phabricator-ssh-hook.sh
+    chmod 755 /usr/share/phabricator-ssh-hook.sh
+
+    cat /opt/bitnami/phabricator/resources/sshd/sshd_config.phabricator.example > /etc/ssh/sshd_config
+    sed -i 's|AuthorizedKeysCommand .*|AuthorizedKeysCommand /usr/share/phabricator-ssh-hook.sh|i' /etc/ssh/sshd_config
+    sed -i 's/AuthorizedKeysCommandUser .*/AuthorizedKeysCommandUser '$PHABRICATOR_SSH_USER'/i' /etc/ssh/sshd_config
+    sed -i 's/AllowUsers.*/AllowUsers '$PHABRICATOR_SSH_USER'/i' /etc/ssh/sshd_config
+    sed -i 's/Port.*/Port '$PHABRICATOR_SSH_PORT_NUMBER'/i' /etc/ssh/sshd_config
+    ln -s /opt/bitnami/php/bin/php /usr/bin/php
+    /opt/bitnami/phabricator/bin/config set diffusion.ssh-port $PHABRICATOR_SSH_PORT_NUMBER
+    service ssh start &
+fi
+
+if [ "${PHABRICATOR_ALLOW_GIT_LFS}" == "true" ] ; then
+    /opt/bitnami/phabricator/bin/config set diffusion.allow-git-lfs true
+fi
+
 nami start --foreground phabricator &
 echo "Starting Apache..."
 exec httpd -f /opt/bitnami/apache/conf/httpd.conf -D FOREGROUND &


### PR DESCRIPTION
**Description of the change**
I added ssh to the container so that one could work with git repos via ssh. I also added two environment variables.
PHABRICATOR_SSH_PORT_NUMBER - for configuring ssh.
PHABRICATOR_ALLOW_GIT_LFS - to enable git lfs

**Benefits**
Phabricator works with ssh and one could close #99 

**Possible drawbacks**
I don't know any

**Applicable issues**
#99 
