### PR TITLE
Install python3-pygments to deliver pygmentize binary

### DIFF
--- a/2019/debian-10/Dockerfile
+++ b/2019/debian-10/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH="/opt/bitnami/apache/bin:/opt/bitnami/php/bin:/opt/bitnami/php/sbin:/op
 
 COPY prebuildfs /
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl dirmngr gnupg libbz2-1.0 libc6 libcom-err2 libcurl4 libexpat1 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu63 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses6 libnettle6 libnghttp2-14 libp11-kit0 libpcre3 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libsqlite3-0 libssh2-1 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5deb1 libtinfo6 libunistring2 libxml2 libxslt1.1 libzip4 openssh-client openssh-server procps python-pygments sudo unzip zlib1g
+RUN install_packages ca-certificates curl dirmngr gnupg libbz2-1.0 libc6 libcom-err2 libcurl4 libexpat1 libffi6 libfreetype6 libgcc1 libgcrypt20 libgmp10 libgnutls30 libgpg-error0 libgssapi-krb5-2 libhogweed4 libicu63 libidn2-0 libjpeg62-turbo libk5crypto3 libkeyutils1 libkrb5-3 libkrb5support0 libldap-2.4-2 liblzma5 libmemcached11 libmemcachedutil2 libncurses6 libnettle6 libnghttp2-14 libp11-kit0 libpcre3 libpng16-16 libpq5 libpsl5 libreadline7 librtmp1 libsasl2-2 libsqlite3-0 libssh2-1 libssl1.1 libstdc++6 libsybdb5 libtasn1-6 libtidy5deb1 libtinfo6 libunistring2 libxml2 libxslt1.1 libzip4 openssh-client openssh-server procps python-pygments python3-pygments sudo unzip zlib1g
 RUN /build/bitnami-user.sh && \
     /build/install-nami.sh
 RUN bitnami-pkg unpack apache-2.4.41-0 --checksum 0364e80e08a89fda2d2d302609f813d5d497b6cb6bcf6643d2770b825abbc0fb


### PR DESCRIPTION
**Description of the change**

Debian [Dockerfile](2019/debian-10/Dockerfile) installs the `python-pygments` package. Unfortnatelly it doesn't contain the required `pygmentize` binary and the Phabricator installation results in unresolved issue with missing `pygmentize` binary in the `$PATH`.

`pygmentize` binary is included in the `python3-pygments` package.

**Benefits**

Syntax highlight support will work out-of-the box.

**Possible drawbacks**

N/A.

**Applicable issues**

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918401

**Additional information**

Original `python-pygments` package was kept installed. It won't break anything and will preserve the possibility to use Python 2 version library.
