### PR TITLE
Fix `MySQL STRICT_ALL_TABLES Mode Not Set` setup issue

### DIFF
--- a/2020/debian-10/docker-compose.yml
+++ b/2020/debian-10/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: 'docker.io/bitnami/mariadb:10.3-debian-10'
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
-      - MARIADB_EXTRA_FLAGS=--local-infile=0
+      - MARIADB_EXTRA_FLAGS=--local-infile=0 --sql_mode=STRICT_ALL_TABLES
     volumes:
       - 'mariadb_data:/bitnami'
   phabricator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: 'docker.io/bitnami/mariadb:10.3-debian-10'
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
-      - MARIADB_EXTRA_FLAGS=--local-infile=0
+      - MARIADB_EXTRA_FLAGS=--local-infile=0 --sql_mode=STRICT_ALL_TABLES
     volumes:
       - 'mariadb_data:/bitnami'
   phabricator:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Adds `STRICT_ALL_TABLES ` to `MARIADB_EXTRA_FLAGS`.

**Benefits**

<!-- What benefits will be realized by the code change? -->

Anyone who installs phabricator get a setup issue. The [recommendation](https://secure.phabricator.com/D8309) is to use this mode.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

No.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

No.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

Extract from the setup issue details (available at http://{host}/config/issue/sql_mode.strict/):
```
On database host "mariadb:3306", the global "sql_mode" setting does not include the "STRICT_ALL_TABLES" mode. Enabling this mode is recommended to generally improve how MySQL handles certain errors.

Without this mode enabled, MySQL will silently ignore some error conditions, including inserts which attempt to store more data in a column than actually fits. This behavior is usually undesirable and can lead to data corruption (by truncating multibyte characters in the middle), data loss (by discarding the data which does not fit into the column), or security concerns (for example, by truncating keys or credentials).

Phabricator is developed and tested in "STRICT_ALL_TABLES" mode so you should normally never encounter these situations, but may run into them if you interact with the database directly, run third-party code, develop extensions, or just encounter a bug in the software.

Enabling "STRICT_ALL_TABLES" makes MySQL raise an explicit error if one of these unusual situations does occur. This is a safer behavior and prevents these situations from causing secret, subtle, and potentially serious issues later on.

You can find more information about this mode (and how to configure it) in the MySQL manual. Usually, it is sufficient to add this to your "my.cnf" file (in the "[mysqld]" section) and then restart "mysqld":

sql_mode=STRICT_ALL_TABLES


Note that if you run other applications against the same database, they may not work in strict mode.

If you can not or do not want to enable "STRICT_ALL_TABLES", you can safely ignore this warning. Phabricator will work correctly with this mode enabled or disabled.
```