### PR TITLE
Fix 'phabricator_regenerate_ssh_keys' function

### DIFF
--- a/2021/debian-10/rootfs/opt/bitnami/scripts/libphabricator.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/libphabricator.sh
@@ -527,6 +527,7 @@ phabricator_enable_vcs_sshd_config() {
 phabricator_regenerate_ssh_keys() {
     local -r ssh_keys_dir="${PHABRICATOR_VOLUME_DIR}/.sshkeys"
     if [[ ! -d "$ssh_keys_dir" ]]; then
+        mkdir -p "$ssh_keys_dir"
         debug_execute ssh-keygen -t dsa -f "${ssh_keys_dir}/ssh_host_dsa_key" -N ""
         debug_execute ssh-keygen -t rsa -f "${ssh_keys_dir}/ssh_host_rsa_key" -N ""
         debug_execute ssh-keygen -t ecdsa -f "${ssh_keys_dir}/ssh_host_ecdsa_key" -N ""


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The 'phabricator_regenerate_ssh_keys' function is not working properly since the keys generation fails since the target directory doesn't exist. This PR fixes that.

**Benefits**

SSH keys are properly autogenerated.

**Possible drawbacks**

None

**Applicable issues**

- Related to https://github.com/bitnami/bitnami-docker-phabricator/issues/166

