### PR TITLE
Fix 'command not found' errors under different circustamces

### DIFF
--- a/2021/debian-10/rootfs/opt/bitnami/scripts/libphabricator.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/libphabricator.sh
@@ -513,9 +513,6 @@ phabricator_enable_vcs_sshd_config() {
     replace_in_file "/etc/ssh/sshd_config" "^\\s*AuthorizedKeysCommandUser\\s+.*$" "AuthorizedKeysCommandUser $PHABRICATOR_SSH_VCS_USER"
     replace_in_file "/etc/ssh/sshd_config" "^\\s*AllowUsers\\s+.*$" "AllowUsers $PHABRICATOR_SSH_VCS_USER"
     replace_in_file "/etc/ssh/sshd_config" "^\\s*Port\\s+.*$" "Port $ssh_port"
-    echo "PermitUserEnvironment yes" >> "/etc/ssh/sshd_config"
-    mkdir -p "/home/${PHABRICATOR_SSH_VCS_USER}/.ssh"
-    echo "PATH=$PATH" > "/home/${PHABRICATOR_SSH_VCS_USER}/.ssh/environment"
 }
 
 #########################

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/libphabricator.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/libphabricator.sh
@@ -513,6 +513,7 @@ phabricator_enable_vcs_sshd_config() {
     replace_in_file "/etc/ssh/sshd_config" "^\\s*AuthorizedKeysCommandUser\\s+.*$" "AuthorizedKeysCommandUser $PHABRICATOR_SSH_VCS_USER"
     replace_in_file "/etc/ssh/sshd_config" "^\\s*AllowUsers\\s+.*$" "AllowUsers $PHABRICATOR_SSH_VCS_USER"
     replace_in_file "/etc/ssh/sshd_config" "^\\s*Port\\s+.*$" "Port $ssh_port"
+    echo "PermitUserEnvironment yes" >> "/etc/ssh/sshd_config"
 }
 
 #########################

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator/setup.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator/setup.sh
@@ -45,17 +45,17 @@ if am_i_root; then
     # temporary files to apply changes and check the syntax with 'visudo' before confirming them.
     sudoers_tmp=$(mktemp)
     ph_sudoers_tmp=$(mktemp)
-    cat /etc/sudoers > "$sudoers_tmp"
+    cp /etc/sudoers "$sudoers_tmp"
     # Ensure 'php' & 'git' commands can be found/executed with 'sudo su'
     replace_in_file "$sudoers_tmp" "^Defaults\s+env_reset$" "Defaults\tenv_reset\nDefaults\tenv_keep += PATH"
     replace_in_file "$sudoers_tmp" "^Defaults\s+secure_path=\"(.*)\"$" "Defaults\tsecure_path=\"\1:$(command -v git | xargs dirname):$(command -v php | xargs dirname)\""
-    visudo -c -q -f "$sudoers_tmp" && cat "$sudoers_tmp" > /etc/sudoers
+    visudo -c -q -f "$sudoers_tmp" && cp "$sudoers_tmp" /etc/sudoers
     # Web Server & VCS users need to be able to sudo as the PH daemon user so they can interact with repositories
     cat > "$ph_sudoers_tmp" << EOF
 ${WEB_SERVER_DAEMON_USER} ALL=(${PHABRICATOR_DAEMON_USER}) SETENV: NOPASSWD: $(command -v git), $(command -v git-http-backend), $(command -v ssh)
 ${PHABRICATOR_SSH_VCS_USER} ALL=(${PHABRICATOR_DAEMON_USER}) SETENV: NOPASSWD: $(command -v git), $(command -v git-upload-pack), $(command -v git-receive-pack), $(command -v ssh)
 EOF
-    visudo -c -q -f "$ph_sudoers_tmp" && cat "$ph_sudoers_tmp" > /etc/sudoers.d/phabricator && chmod 440 /etc/sudoers.d/phabricator
+    visudo -c -q -f "$ph_sudoers_tmp" && cp "$ph_sudoers_tmp" /etc/sudoers.d/phabricator && chmod 440 /etc/sudoers.d/phabricator
     rm "$ph_sudoers_tmp" "$sudoers_tmp"
     # We also need to ensure the PATH is properly set when accessing via SSH
     for user in "$PHABRICATOR_DAEMON_USER" "$PHABRICATOR_SSH_VCS_USER"; do

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator/setup.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator/setup.sh
@@ -46,7 +46,7 @@ if am_i_root; then
     sudoers_tmp=$(mktemp)
     ph_sudoers_tmp=$(mktemp)
     cat /etc/sudoers > "$sudoers_tmp"
-    # Ensure 'php' & 'pip' commands can be found/executed with 'sudo su'
+    # Ensure 'php' & 'git' commands can be found/executed with 'sudo su'
     replace_in_file "$sudoers_tmp" "^Defaults\s+env_reset$" "Defaults\tenv_reset\nDefaults\tenv_keep += PATH"
     replace_in_file "$sudoers_tmp" "^Defaults\s+secure_path=\"(.*)\"$" "Defaults\tsecure_path=\"\1:$(command -v git | xargs dirname):$(command -v php | xargs dirname)\""
     visudo -c -q -f "$sudoers_tmp" && cat "$sudoers_tmp" > /etc/sudoers

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator/setup.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator/setup.sh
@@ -43,10 +43,15 @@ if am_i_root; then
     debug_execute usermod -p NP "$PHABRICATOR_SSH_VCS_USER"
     # Web Server & VCS users need to be able to sudo as the PH daemon user so they can interact with repositories
     cat > /etc/sudoers.d/phabricator << EOF
-"${WEB_SERVER_DAEMON_USER}" ALL=("${PHABRICATOR_DAEMON_USER}") SETENV: NOPASSWD: $(command -v git), $(command -v git-http-backend), $(command -v ssh)
-"${PHABRICATOR_SSH_VCS_USER}" ALL=("${PHABRICATOR_DAEMON_USER}") SETENV: NOPASSWD: $(command -v git), $(command -v git-upload-pack), $(command -v git-receive-pack), $(command -v ssh)
+${WEB_SERVER_DAEMON_USER} ALL=(${PHABRICATOR_DAEMON_USER}) SETENV: NOPASSWD: $(command -v git), $(command -v git-http-backend), $(command -v ssh)
+${PHABRICATOR_SSH_VCS_USER} ALL=(${PHABRICATOR_DAEMON_USER}) SETENV: NOPASSWD: $(command -v git), $(command -v git-upload-pack), $(command -v git-receive-pack), $(command -v ssh)
 EOF
     chmod 440 /etc/sudoers.d/phabricator
+    # SSH + sudo combination resets the environment and we're finding a lot of issues related to command unable to find binaries
+    # TODO: find a better way to define the envionment for daemon + vcs users combined with sudo actions.
+    for binary in "php" "git" "git-http-backend" "git-upload-pack" "git-receive-pack"; do
+        ln -s "$(command -v "$binary")" "/usr/bin/${binary}"
+    done
 
     # Ensure required directories exists and have proper permissions
     info "Configuring file permissions for Phabricator"

--- a/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator/setup.sh
+++ b/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator/setup.sh
@@ -47,8 +47,8 @@ ${WEB_SERVER_DAEMON_USER} ALL=(${PHABRICATOR_DAEMON_USER}) SETENV: NOPASSWD: $(c
 ${PHABRICATOR_SSH_VCS_USER} ALL=(${PHABRICATOR_DAEMON_USER}) SETENV: NOPASSWD: $(command -v git), $(command -v git-upload-pack), $(command -v git-receive-pack), $(command -v ssh)
 EOF
     chmod 440 /etc/sudoers.d/phabricator
-    # SSH + sudo combination resets the environment and we're finding a lot of issues related to command unable to find binaries
-    # TODO: find a better way to define the envionment for daemon + vcs users combined with sudo actions.
+    # SSH + sudo combination resets the environment and we're finding a lot of issues related to commands unable to find binaries
+    # TODO: find a better way to define the environment for daemon + vcs users combined with sudo actions.
     for binary in "php" "git" "git-http-backend" "git-upload-pack" "git-receive-pack"; do
         ln -s "$(command -v "$binary")" "/usr/bin/${binary}"
     done


### PR DESCRIPTION
**Description of the change**

The **PATH** environment variable is reseted under certain circumstances (e.g. when using `sudo` to execute commands as a different user, when accessing via SSH, etc.). This is highly problematic when you try to use Phabricator to host your repositories and access them via SSH because:

- You need to access the container via SSH using a **PHABRICATOR_SSH_VCS_USER** user.
- SSH daemon is configured to use Phabricator CLI to check authorised keys (requires customisations at `/etc/ssh/sshd`).
- The **PHABRICATOR_SSH_VCS_USER** user needs to perform some actions as the **PHABRICATOR_DAEMON_USER** user (requires `/etc/sudoers` customisations).
- Nor `php` nor `git` related commands are in default linux paths. 

After some investigation, I could get it working by:

- Adapting `secure_path ` in `/etc/sudoers`.
- Adding **PATH** to `env_keep` in `/etc/sudoers`.
- Using `PermitUserEnvironment yes` in `/etc/ssh/sshd_config`..
- Adding the **PATH** to `/home/git/.ssh/environment` and `/home/phabricator/.ssh/environment`.

**Benefits**

Users can actually use Phabricator with hosted repositories using SSH authentication.

**Possible drawbacks**

None

**Applicable issues**

- https://github.com/bitnami/bitnami-docker-phabricator/issues/166
