### PR TITLE
Fix default password in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Available environment variables:
 - `APACHE_HTTP_PORT_NUMBER`: Port used by Apache for HTTP. Default: **8080**
 - `APACHE_HTTPS_PORT_NUMBER`: Port used by Apache for HTTPS. Default: **8443**
 - `PHABRICATOR_USERNAME`: Phabricator application username. Default: **user**
-- `PHABRICATOR_PASSWORD`: Phabricator application password. Default: **bitnami**
+- `PHABRICATOR_PASSWORD`: Phabricator application password. Default: **bitnami1**
 - `PHABRICATOR_EMAIL`: Phabricator application email. Default: **user@example.com**
 - `PHABRICATOR_FIRSTNAME`: Phabricator user first name. Default: **FirstName**
 - `PHABRICATOR_LASTNAME`: Phabricator user last name. Default: **LastName**


### PR DESCRIPTION
**Description of the change**

This fixes the documented default password.

The correct default password is `bitnami1` as per https://github.com/bitnami/bitnami-docker-phabricator/blob/26e9d1cfd2c401ce4d60fd254bb7f50d095bbc3a/2021/debian-10/rootfs/opt/bitnami/scripts/phabricator-env.sh#L113.

**Benefits**

One can try out phabricator without manually setting a password beforehand.

**Possible drawbacks**

None at all, I guess :)

**Applicable issues**

n / a

**Additional information**

n / a